### PR TITLE
fix: naive vs timezone aware date comparison for watermark

### DIFF
--- a/watermarker/templatetags/watermark.py
+++ b/watermarker/templatetags/watermark.py
@@ -6,6 +6,7 @@ import logging
 import os
 import traceback
 
+from django.utils import timezone
 from django.conf import settings
 from django import template
 from watermarker import utils
@@ -152,7 +153,7 @@ class Watermarker(object):
             modified = datetime.fromtimestamp(os.path.getmtime(wm_path))
 
             # only return the old file if things appear to be the same
-            if modified >= watermark.date_updated:
+            if timezone.make_aware(modified, timezone.get_default_timezone()) >= watermark.date_updated:
                 log.info('Watermark exists and has not changed.  Bailing out.')
                 return wm_url
 


### PR DESCRIPTION
This commit fixes a bug with django 1.4 when comparing previous watermarked image last_modified date with naive non-timezoned aware date.
Fixing the "can't compare offset-naive and offset-aware datetimes" error.

Regards, 

Olivier.