### PR TITLE
discard RGBA information when composing image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     maintainer='Basil Shubin',
     maintainer_email='basil.shubin@gmail.com',
     install_requires=[
+        'packaging',
         'django>=1.4',
         'django-appconf',
         'pillow',


### PR DESCRIPTION
When using Pillow 7.1.2 (actually Pillow >= 4.2) an error occurs when trying to apply a watermark to a JPG file: `Cannot write mode RGBA as JPEG` (See https://github.com/python-pillow/Pillow/issues/2609 for more information).

This should fix that.
