### PR TITLE
Image.ANTIALIAS is deprecated

### DIFF
--- a/watermarker/templatetags/watermark.py
+++ b/watermarker/templatetags/watermark.py
@@ -69,7 +69,7 @@ class Watermarker(object):
         # determine the actual value that the parameters provided will render
         random_position = bool(position is None or str(position).lower() == "r")
         scale = utils.determine_scale(scale, target, mark)
-        mark = mark.resize(scale, resample=Image.ANTIALIAS)
+        mark = mark.resize(scale, resample=Image.LANCZOS)
         rotation = utils.determine_rotation(rotation, mark)
         pos = utils.determine_position(position, target, mark)
 


### PR DESCRIPTION
Antialias is deprecated after PILLOW 9.5.0, was replaced for Image.LANCZOS